### PR TITLE
Add Auferet (AI game master) as a Writer tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ The ultimate resource hub for AI-powered game development tools. Discover cuttin
 | [Notebook.ai](https://github.com/indentlabs/notebook)                                          | Notebook.ai is a set of tools for writers, game designers, and roleplayers to create magnificent universes – and everything within them.                                                  |               |              |  Writer  |
 | [Novel](https://github.com/steven-tey/novel)                                                   | Notion-style WYSIWYG editor with AI-powered autocompletions.                                                                                                                                   |               |              |  Writer  |
 | [NovelAI](https://novelai.net/)                                                                | Driven by AI, painlessly construct unique stories, thrilling tales, seductive romances, or just fool around.                                                                                 |               |              |  Writer  |
+| [Auferet](https://auferet.com/) | An AI game master for solo text adventures and tabletop-style RPGs, with persistent memory of your story and your own uploaded lore. |  |  | Writer |
 
 
 <p style="text-align: right;"><a href="#table-of-contents">^ Back to Contents ^</a></p>


### PR DESCRIPTION
Adds **Auferet** to the list as a Writer-type tool, next to NovelAI.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs. It keeps a persistent memory of your story and lets you upload your own lore, so the world stays consistent across long sessions. It runs as a web app and a published Android app, and is actively maintained. The link resolves (HTTP 200) and the row follows the existing table format.
